### PR TITLE
Rename attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,23 @@ In layout:
 	android:layout_height="wrap_content"
 	android:layout_alignParentBottom="true"
 	android:layout_alignParentLeft="true"
-	app:numberColor="@android:color/white"
-	app:arrowColor="@android:color/white"
-	app:backgroundColor="@color/colorAccent"
-	app:max="1000"
-	app:min="50"
-	app:value="95"/>
+	app:snp_numberColor="@android:color/white"
+	app:snp_arrowColor="@android:color/white"
+	app:snp_backgroundColor="@color/colorAccent"
+	app:snp_max="1000"
+	app:snp_min="50"
+	app:snp_value="95"/>
 ```
 
 Attributes:
 
 ``` xml
-	<attr name="min" format="integer"/>
-	<attr name="max" format="integer"/>
-	<attr name="value" format="integer"/>
-	<attr name="arrowColor" format="color"/>
-	<attr name="backgroundColor" format="color"/>
-	<attr name="numberColor" format="color"/>
+	<attr name="snp_min" format="integer"/>
+	<attr name="snp_max" format="integer"/>
+	<attr name="snp_value" format="integer"/>
+	<attr name="snp_arrowColor" format="color"/>
+	<attr name="snp_backgroundColor" format="color"/>
+	<attr name="snp_numberColor" format="color"/>
 ```
 
 To set changed value implement the `OnValueChangeListener` listener and on `onValueChange` return `true`

--- a/SwipeNumberPicker/src/main/java/com/vi/swipenumberpicker/SwipeNumberPicker.java
+++ b/SwipeNumberPicker/src/main/java/com/vi/swipenumberpicker/SwipeNumberPicker.java
@@ -78,13 +78,13 @@ public class SwipeNumberPicker extends TextView {
 				R.styleable.SwipeNumberPicker, 0, 0);
 		if (attrs != null) {
 			try {
-				mPrimaryValue = attrs.getInteger(R.styleable.SwipeNumberPicker_value, 0);
-				mMinValue = attrs.getInteger(R.styleable.SwipeNumberPicker_min, -9999);
-				mMaxValue = attrs.getInteger(R.styleable.SwipeNumberPicker_max, 9999);
+				mPrimaryValue = attrs.getInteger(R.styleable.SwipeNumberPicker_snp_value, 0);
+				mMinValue = attrs.getInteger(R.styleable.SwipeNumberPicker_snp_min, -9999);
+				mMaxValue = attrs.getInteger(R.styleable.SwipeNumberPicker_snp_max, 9999);
 
-				mArrowColor = attrs.getColor(R.styleable.SwipeNumberPicker_arrowColor, context.getResources().getColor(R.color.arrows));
-				mBackgroundColor = attrs.getColor(R.styleable.SwipeNumberPicker_backgroundColor, context.getResources().getColor(R.color.background));
-				mNumColor = attrs.getColor(R.styleable.SwipeNumberPicker_numberColor, context.getResources().getColor(R.color.text));
+				mArrowColor = attrs.getColor(R.styleable.SwipeNumberPicker_snp_arrowColor, context.getResources().getColor(R.color.arrows));
+				mBackgroundColor = attrs.getColor(R.styleable.SwipeNumberPicker_snp_backgroundColor, context.getResources().getColor(R.color.background));
+				mNumColor = attrs.getColor(R.styleable.SwipeNumberPicker_snp_numberColor, context.getResources().getColor(R.color.text));
 			} finally {
 				attrs.recycle();
 			}

--- a/SwipeNumberPicker/src/main/res/values/attrs.xml
+++ b/SwipeNumberPicker/src/main/res/values/attrs.xml
@@ -1,12 +1,12 @@
 <resources>
 
 	<declare-styleable name="SwipeNumberPicker">
-		<attr name="min" format="integer"/>
-		<attr name="max" format="integer"/>
-		<attr name="value" format="integer"/>
-		<attr name="arrowColor" format="color"/>
-		<attr name="backgroundColor" format="color"/>
-		<attr name="numberColor" format="color"/>
+		<attr name="snp_min" format="integer"/>
+		<attr name="snp_max" format="integer"/>
+		<attr name="snp_value" format="integer"/>
+		<attr name="snp_arrowColor" format="color"/>
+		<attr name="snp_backgroundColor" format="color"/>
+		<attr name="snp_numberColor" format="color"/>
 	</declare-styleable>
 
 </resources>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:snp="http://schemas.android.com/apk/res-auto"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
                 xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -65,8 +65,8 @@
         android:layout_below="@id/tv_implemented_lbl"
         android:layout_toEndOf="@id/tv_hello"
         android:layout_toRightOf="@id/tv_hello"
-        snp:arrowColor="@color/colorPrimary"
-        snp:numberColor="@color/colorPrimaryDark"/>
+        app:snp_arrowColor="@color/colorPrimary"
+        app:snp_numberColor="@color/colorPrimaryDark"/>
 
     <TextView
         android:id="@+id/tv_result_1"
@@ -96,12 +96,12 @@
         android:layout_below="@id/tv_custom_lbl"
         android:layout_toEndOf="@id/tv_hello"
         android:layout_toRightOf="@id/tv_hello"
-        snp:arrowColor="@android:color/white"
-        snp:backgroundColor="@color/colorAccent"
-        snp:max="1000"
-        snp:min="50"
-        snp:numberColor="@android:color/white"
-        snp:value="95"/>
+        app:snp_arrowColor="@android:color/white"
+        app:snp_backgroundColor="@color/colorAccent"
+        app:snp_max="1000"
+        app:snp_min="50"
+        app:snp_numberColor="@android:color/white"
+        app:snp_value="95"/>
 
     <TextView
         android:id="@+id/tv_result_2"


### PR DESCRIPTION
Build failed because of attributes. They should be prefixed to avoid any issue.

This PR fixes the following issue:
Error:(407) Attribute "max" has already been defined
Error:Execution failed for task ':ScoreIt:processDebugResources'.
com.android.ide.common.process.ProcessException: org.gradle.process.internal.ExecException: Process 'command 'D:\Android\SDK\build-tools\23.0.2\aapt.exe'' finished with non-zero exit value 1